### PR TITLE
Added multiple server, each for separate language model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ disable original `res_http_websocket` since it contains bugs
 exten = 1,1,Answer
 same = n,Wait(1)
 same = n,SpeechCreate
+same = n,Set(SPEECH_ENGINE(language)=${CHANNEL(language)})
 same = n,SpeechBackground(hello)
 same = n,Verbose(0,Result was ${SPEECH_TEXT(0)})
 ```

--- a/conf/res-speech-vosk.conf
+++ b/conf/res-speech-vosk.conf
@@ -1,3 +1,9 @@
 [general]
 log-level = 0
 url = ws://localhost:2700
+
+[en]
+url = ws://localhost:2700
+
+[ru]
+url = ws://localhost:2700


### PR DESCRIPTION
I has been added support for load and select for the different language models per server. Of course it will be the one server with single model, but in real case each model may work on the different server or the different docker container.